### PR TITLE
Fix various linting problems

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -419,7 +419,7 @@ paths:
           description: >
             Failed to delete resource access request decisions from the
             decision database.
-  /v2/prompting/decisions/{snap}:
+  /v2/prompting/decisions/snap/{snap}:
     GET:
       operationId: getDecisionsForSnap
       summary: Get stored decisions for a snap
@@ -468,7 +468,7 @@ paths:
           description: >
             Failed to delete resource access request decisions for the given
             snap from the decision database.
-  /v2/prompting/decisions/{snap}/{app}:
+  /v2/prompting/decisions/snap/{snap}/{app}:
     GET:
       operationId: getDecisionsForSnapApp
       summary: Get stored decisions for an app
@@ -518,7 +518,7 @@ paths:
           description: >
             Failed to delete resource access request decisions for the given
             app within the given snap from the decision database.
-  /v2/prompting/decision-id/{id}:
+  /v2/prompting/decisions/id/{id}:
     GET:
       operationId: getDecisionWithId
       summary: Get a particular resource access request decision

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -244,16 +244,16 @@ components:
         The name of the snap for which to get resource access request
         decisions.
       name: snap
-      in: path
-      required: true
+      in: query
+      required: false
       schema:
         $ref: "#/components/schemas/snap"
     app-param:
       description: >
         The name of the app for which to get resource access request decisions.
       name: app
-      in: path
-      required: true
+      in: query
+      required: false
       schema:
         $ref: "#/components/schemas/app"
     id-param:
@@ -358,12 +358,19 @@ paths:
       operationId: getDecisions
       summary: Get existing resource access request decisions
       description: >
-        Retrieve all existing resource access request decisions from the
-        decision database.
+        Retrieve existing resource access request decisions from the decision
+        database.
+        If the snap parameter is given, only retrieve resource access requests
+        for that snap.
+        If the app parameter is given along with the snap parameter, only
+        retrieve resource access requests for that app within the given snap.
+        The app parameter is ignored if the snap parameter is not given.
       tags:
         - decisions
       parameters:
         - $ref: "#/components/parameters/follow-param"
+        - $ref: "#/components/parameters/snap-param"
+        - $ref: "#/components/parameters/app-param"
       responses:
         "200":
           description: >
@@ -400,16 +407,24 @@ paths:
             Failed to create the given resource access request decision.
     DELETE:
       operationId: deleteDecisions
-      summary: Delete all decisions
+      summary: Delete resource access request decisions
       description: >
-        Delete all previously-stored resource access request decisions from
+        Delete previously-stored resource access request decisions from
         the decision database.
+        If the snap parameter is given, only delete resource access requests
+        for that snap.
+        If the app parameter is given along with the snap parameter, only
+        delete resource access requests for that app within the given snap.
+        The app parameter is ignored if the snap parameter is not given.
       tags:
         - decisions
+      parameters:
+        - $ref: "#/components/parameters/snap-param"
+        - $ref: "#/components/parameters/app-param"
       responses:
         "200":
           description: >
-            Successfully deleted all resource access request decisions.
+            Successfully deleted resource access request decisions.
             All deleted decisions can be found in the response content.
           content:
             application/json:
@@ -419,106 +434,7 @@ paths:
           description: >
             Failed to delete resource access request decisions from the
             decision database.
-  /v2/prompting/decisions/snap/{snap}:
-    GET:
-      operationId: getDecisionsForSnap
-      summary: Get stored decisions for a snap
-      description: >
-        Get all resource access request decisions for all apps within the
-        given snap.
-      tags:
-        - decisions
-      parameters:
-        - $ref: "#/components/parameters/snap-param"
-        - $ref: "#/components/parameters/follow-param"
-      responses:
-        "200":
-          description: >
-            Successfully retrieved the resource access request decisions for
-            the given snap.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/stored-decisions"
-        "404":
-          description: >
-            Failed to retrieve the resource access request decisions for the
-            given snap.
-    DELETE:
-      operationId: deleteDecisionsForSnap
-      summary: Delete stored decisions for a snap
-      description: >
-        Delete all previously-stored resource access request decisions for all
-        apps within the given snap from the decision database.
-      tags:
-        - decisions
-      parameters:
-        - $ref: "#/components/parameters/snap-param"
-      responses:
-        "200":
-          description: >
-            Successfully deleted all resource access request decisions for the
-            given snap.
-            All deleted decisions can be found in the response content.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/stored-decisions"
-        "404":
-          description: >
-            Failed to delete resource access request decisions for the given
-            snap from the decision database.
-  /v2/prompting/decisions/snap/{snap}/{app}:
-    GET:
-      operationId: getDecisionsForSnapApp
-      summary: Get stored decisions for an app
-      description: >
-        Get all resource access request decisions for the given app within the
-        given snap.
-      tags:
-        - decisions
-      parameters:
-        - $ref: "#/components/parameters/snap-param"
-        - $ref: "#/components/parameters/app-param"
-      responses:
-        "200":
-          description: >
-            Successfully retrieved the resource access request decisions for
-            the given app within the given snap.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/stored-decisions"
-        "404":
-          description: >
-            Failed to retrieve the resource access request decisions for the
-            given app within the given snap.
-    DELETE:
-      operationId: deleteDecisionsForSnapApp
-      summary: Delete stored decisions for an app
-      description: >
-        Delete all previously-stored resource access request decisions for the
-        given app within the given snap.
-      tags:
-        - decisions
-      parameters:
-        - $ref: "#/components/parameters/snap-param"
-        - $ref: "#/components/parameters/app-param"
-      responses:
-        "200":
-          description: >
-            Successfully deleted all resource access request decisions for the
-            given app within the given snap.
-            All deleted decisions can be found in the response content.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/stored-decisions"
-        "404":
-          description: >
-            Failed to delete resource access request decisions for the given
-            app within the given snap from the decision database.
-  /v2/prompting/decisions/id/{id}:
+  /v2/prompting/decisions/{id}:
     GET:
       operationId: getDecisionWithId
       summary: Get a particular resource access request decision

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -280,6 +280,11 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/decision-contents"
+tags:
+  - name: requests
+    description: Methods related to outstanding resource access requests.
+  - name: decisions
+    description: Methods related to previously-stored resource access request decisions.
 paths:
   /v2/prompting/requests:
     GET:
@@ -287,6 +292,8 @@ paths:
       summary: Retrieve all resource access requests
       description: >
         Retrieve all outstanding resource access requests.
+      tags:
+        - requests
       parameters:
         - $ref: "#/components/parameters/follow-param"
       responses:
@@ -311,6 +318,8 @@ paths:
       description: >
         Retrieve the resource access request information corresponding to the
         given ID.
+      tags:
+        - requests
       parameters:
         - $ref: "#/components/parameters/id-param"
       responses:
@@ -332,6 +341,8 @@ paths:
         Respond to the given resource access request, providing information
         collected by prompting the user for a decision about access to the
         corresponding resource.
+      tags:
+        - requests
       parameters:
         - $ref: "#/components/parameters/id-param"
         - $ref: "#/components/parameters/response-param"
@@ -349,6 +360,8 @@ paths:
       description: >
         Retrieve all existing resource access request decisions from the
         decision database.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/follow-param"
       responses:
@@ -370,6 +383,8 @@ paths:
       description: >
         Directly create a new resource access request rule without having
         previously been prompted by a resource access request.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/decision-param"
       responses:
@@ -389,6 +404,8 @@ paths:
       description: >
         Delete all previously-stored resource access request decisions from
         the decision database.
+      tags:
+        - decisions
       responses:
         "200":
           description: >
@@ -409,6 +426,8 @@ paths:
       description: >
         Get all resource access request decisions for all apps within the
         given snap.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/snap-param"
         - $ref: "#/components/parameters/follow-param"
@@ -431,6 +450,8 @@ paths:
       description: >
         Delete all previously-stored resource access request decisions for all
         apps within the given snap from the decision database.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/snap-param"
       responses:
@@ -454,6 +475,8 @@ paths:
       description: >
         Get all resource access request decisions for the given app within the
         given snap.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/snap-param"
         - $ref: "#/components/parameters/app-param"
@@ -476,6 +499,8 @@ paths:
       description: >
         Delete all previously-stored resource access request decisions for the
         given app within the given snap.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/snap-param"
         - $ref: "#/components/parameters/app-param"
@@ -500,6 +525,8 @@ paths:
       description: >
         Get the resource access request decision corresponding to the given
         request ID.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/id-param"
       responses:
@@ -520,6 +547,8 @@ paths:
       description: >
         Modify the resource access request response corresponding to the given
         request ID.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/id-param"
         - $ref: "#/components/parameters/response-param"
@@ -541,6 +570,8 @@ paths:
       summary: Delete a resource access request decision.
       description: >
         Delete the resource access request decision with the given ID.
+      tags:
+        - decisions
       parameters:
         - $ref: "#/components/parameters/id-param"
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -586,4 +586,5 @@ paths:
         "404":
           description: >
             No resource access request decision found with the given ID.
+            Failed to delete decision.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -283,6 +283,7 @@ components:
 paths:
   /v2/prompting/requests:
     GET:
+      operationId: getRequests
       summary: Retrieve all resource access requests
       description: >
         Retrieve all outstanding resource access requests.
@@ -305,6 +306,7 @@ paths:
             Failed to retrieve resource access requests.
   /v2/prompting/requests/{id}:
     GET:
+      operationId: getRequestWithId
       summary: Retrieve the request information for a particular request ID
       description: >
         Retrieve the resource access request information corresponding to the
@@ -324,6 +326,7 @@ paths:
           description: >
             No resource access request found with the given ID.
     POST:
+      operationId: respondToRequestWithId
       summary: Respond to the given resource access request
       description: >
         Respond to the given resource access request, providing information
@@ -341,6 +344,7 @@ paths:
             No request found with the given ID, ignoring response.
   /v2/prompting/decisions:
     GET:
+      operationId: getDecisions
       summary: Get existing resource access request decisions
       description: >
         Retrieve all existing resource access request decisions from the
@@ -361,6 +365,7 @@ paths:
             Failed to retrieve existing resource access request decisions from
             the decision database.
     POST:
+      operationId: addDecision
       summary: Create a new resource access request decision
       description: >
         Directly create a new resource access request rule without having
@@ -379,6 +384,7 @@ paths:
           description: >
             Failed to create the given resource access request decision.
     DELETE:
+      operationId: deleteDecisions
       summary: Delete all decisions
       description: >
         Delete all previously-stored resource access request decisions from
@@ -398,6 +404,7 @@ paths:
             decision database.
   /v2/prompting/decisions/{snap}:
     GET:
+      operationId: getDecisionsForSnap
       summary: Get stored decisions for a snap
       description: >
         Get all resource access request decisions for all apps within the
@@ -419,6 +426,7 @@ paths:
             Failed to retrieve the resource access request decisions for the
             given snap.
     DELETE:
+      operationId: deleteDecisionsForSnap
       summary: Delete stored decisions for a snap
       description: >
         Delete all previously-stored resource access request decisions for all
@@ -441,6 +449,7 @@ paths:
             snap from the decision database.
   /v2/prompting/decisions/{snap}/{app}:
     GET:
+      operationId: getDecisionsForSnapApp
       summary: Get stored decisions for an app
       description: >
         Get all resource access request decisions for the given app within the
@@ -462,6 +471,7 @@ paths:
             Failed to retrieve the resource access request decisions for the
             given app within the given snap.
     DELETE:
+      operationId: deleteDecisionsForSnapApp
       summary: Delete stored decisions for an app
       description: >
         Delete all previously-stored resource access request decisions for the
@@ -485,6 +495,7 @@ paths:
             app within the given snap from the decision database.
   /v2/prompting/decisions/{id}:
     GET:
+      operationId: getDecisionWithId
       summary: Get a particular resource access request decision
       description: >
         Get the resource access request decision corresponding to the given
@@ -504,6 +515,7 @@ paths:
           description: >
             No resource access request decision found with the given ID.
     POST:
+      operationId: modifyDecisionWithId
       summary: Modify an existing resource access request decision
       description: >
         Modify the resource access request response corresponding to the given
@@ -525,6 +537,7 @@ paths:
             No resource access request decision found with the given ID.
             Ignore the given response information.
     DELETE:
+      operationId: deleteDecisionWithId
       summary: Delete a resource access request decision.
       description: >
         Delete the resource access request decision with the given ID.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -280,14 +280,6 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/decision-contents"
-    changed-decisions-param:
-      description: >
-        The resource access request decisions which have changed.
-      name: changed-decisions
-      in: query
-      required: true
-      schema:
-        $ref: "$/components/schemas/changed-decisions"
 paths:
   /v2/prompting/requests:
     GET:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,6 @@
 openapi: 3.1.0
+servers:
+  - url: http://localhost
 info:
   title: Prompting API
   summary: The API for communication between snapd and prompt UI clients

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -518,7 +518,7 @@ paths:
           description: >
             Failed to delete resource access request decisions for the given
             app within the given snap from the decision database.
-  /v2/prompting/decisions/{id}:
+  /v2/prompting/decision-id/{id}:
     GET:
       operationId: getDecisionWithId
       summary: Get a particular resource access request decision


### PR DESCRIPTION
Since adding the `vacuum` linter, various problems have been identified in the openapi.yaml spec.

Most notably, the collision between `/v2/prompting/decisions/{snap}` and `/v2/prompting/decisions/{id}`, for which it is ambiguous whether the path parameter corresponds to `snap` or `id`.

The proposed solution is to move the decisions-by-ID endpoint to `/v2/prompting/decision-id/{id}`.

The alternative could be to use:

- `/v2/prompting/decisions/by-snap/{snap}`
- `/v2/prompting/decisions/by-snap/{snap}/{app}`
- `/v2/prompting/decisions/by-id/{id}`

but this seems clumsier than simply moving the decisions by ID to their own endpoint.